### PR TITLE
chore: move environment variables to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,6 @@ If you do not want to install Mongo, Redis, Node and Yarn, follow these steps.
 ### Steps
 
 - Download this source code into a working directory. (Keep the directory name as "abibliadigital")
-- Create `.env` file:
-
-```
-MONGODB_URI=mongodb://abibliadigital-mongo/abibliadigital
-NODE_ENV="development"
-SECRET_KEY=""
-REDIS_URL="redis://abibliadigital-redis"
-```
-
 - Run the project using the following command: `docker-compose up`
 - Visit `localhost:3000/api/check` to see the running api!
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,17 @@ version: '3'
 services:
   abibliadigital:
     build: ./docker-api
-    command: ["bash","/usr/src/api/start.sh"]
+    command: [ "bash", "/usr/src/api/start.sh" ]
     ports:
       - "3000:3000"
     expose:
       - "3000"
     container_name: abibliadigital
+    environment:
+      - MONGODB_URI=mongodb://abibliadigital-mongo/abibliadigital
+      - NODE_ENV="development"
+      - SECRET_KEY=""
+      - REDIS_URL=redis://abibliadigital-redis
     volumes:
       - ../abibliadigital:/usr/src/api
     depends_on:
@@ -34,5 +39,6 @@ services:
       - "6379:6379"
     expose:
       - "6379"
+    restart: always
     volumes:
-       - $PWD/redis-data:/var/lib/redis
+      - ../redis-data:/var/lib/redis


### PR DESCRIPTION
## Description
Removed the need to create an .env file to run the application locally with docker. Now the environment variables are already in docker-compose.yml. 


- [X] Updated the documentation as well.