### PR TITLE
fix: nonsensitive verses search added #412

### DIFF
--- a/controllers/verse.js
+++ b/controllers/verse.js
@@ -114,9 +114,10 @@ export const search = async (req, res) => {
     var expression = new RegExp(
       '' +
         search
+          .toLowerCase()
           .split(' ')
           .map(function (word) {
-            return '(?=.*\\b' + word + '\\b)'
+            return '(?=.*' + diacriticSensitiveRegex(word) + ')'
           })
           .join('') +
         '.+'
@@ -124,7 +125,7 @@ export const search = async (req, res) => {
 
     const verses = await Verse.find({
       version,
-      text: expression
+      text: {$regex: expression, $options: 'i' }
     })
 
     res.json({
@@ -167,4 +168,13 @@ const getItem = async params => {
     number: parseInt(number),
     version
   })
+}
+
+const diacriticSensitiveRegex = (string = '') => {
+  return string
+    .replace(/a/g, '[a,á,à,ä,â]')
+    .replace(/e/g, '[e,é,ë,è]')
+    .replace(/i/g, '[i,í,ï,ì]')
+    .replace(/o/g, '[o,ó,ö,ò]')
+    .replace(/u/g, '[u,ü,ú,ù]')
 }


### PR DESCRIPTION
## Description
* The word boundary \b was removed in the function **search** to allow get substrings (e.g. **princi** returns verses with the word **princípio**);
* It was implemented the function **diacriticSensitiveRegex(string)**, which ignore the accents using Regex; and
* Now the property **text** in the **Verse.find()** method receive the $regex and $options operators, and the $options operator receive the value **"i"**, to disable the case sensitive.

## Motivation or Context
The resource: POST https://www.abibliadigital.com.br/api/verses/search was extremely case sensitive and did not return substrings, like it's explained in the issue [Permitir buscas por palavras sem camelcase e desconsiderar acentuações #412](https://github.com/omarciovsena/abibliadigital/issues/412).

## How Has This Been Tested?
It was registered only some verses in a collection (it explains the lower number of occurrences) and made some requests in the Postman extension to VS Code.
### Body 1:
```
{
  "version": "nvi",
  "search": "te"
}
```

### Response 1:
```
{
    "occurrence": 2,
    "verses": [
        {
            "book": {
                "abbrev": {
                    "pt": "gn",
                    "en": "gn"
                },
                "author": "Moisés",
                "chapters": 50,
                "group": "Pentateuco",
                "name": "Gênesis",
                "testament": "VT"
            },
            "chapter": 1,
            "number": 1,
            "text": "No princípio Deus criou os céus e a terra."
        },
        {
            "book": {
                "abbrev": {
                    "pt": "hb",
                    "en": "hb"
                },
                "author": "Desconhecido",
                "chapters": 13,
                "group": "Cartas",
                "name": "Hebreus",
                "testament": "NT"
            },
            "chapter": 5,
            "number": 10,
            "text": "sendo designado por Deus sumo sacerdote, segundo a ordem de Melquisedeque."
        }
    ]
}
```

In the request above it's found the words "**te**rra" and "sacerdo**te**".

### Body 2:
```
{
  "version": "nvi",
  "search": "no princi"
}
```

### Response 2:
```
{
    "occurrence": 1,
    "verses": [
        {
            "book": {
                "abbrev": {
                    "pt": "gn",
                    "en": "gn"
                },
                "author": "Moisés",
                "chapters": 50,
                "group": "Pentateuco",
                "name": "Gênesis",
                "testament": "VT"
            },
            "chapter": 1,
            "number": 1,
            "text": "No princípio Deus criou os céus e a terra."
        }
    ]
}
```

In the request above it's found the phrase "**No princí**pio". Look at the body does not include the accent, but in the response the word has an accent.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
