### PR TITLE
creat script for user in Documentation.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -323,6 +323,30 @@
     notifications: true
   }
   ```
+ 
+> If you prefer, you can download the Axios library and use the script to create an account and obtain a token, in case you don't have a way to get it in mind.
+> `npm install axios`
+> `node script.js`
+> ```js
+>  const axios = require('axios');
+>  const data = {
+>  name: "Name",
+>  email: "email@email.com",
+>  password: "1234...", // YOU PASSWORD
+>  notifications: true
+> };
+>
+> axios.post('https://www.abibliadigital.com.br/api/users', data, {
+>  headers: { 'Content-Type': 'application/json' }
+> })
+> .then(response => {
+>  console.log(response.data);
+> })
+> .catch(error => {
+>  console.error('Erro:', error.response.data);
+> });
+> ```
+
 </details>
 
 <details>


### PR DESCRIPTION
Include a script in JavaScript using the Axios library for new users to create their account using NodeJS and easily obtain a token, in case there is no specific approach. The documentation does not provide examples or teach how to create an account while obtaining it. With the execution of the script, it becomes accessible.

![Captura de tela de 2024-10-23 09-27-54](https://github.com/user-attachments/assets/10d00011-0458-46df-8050-5d254886a521)

> [!NOTE]
> The script is just a template; it is understood that the user will need to edit information, such as the password. Additionally, the information will be obtained via the CLI, where it should also be noted that the token is displayed temporarily after closing the terminal.